### PR TITLE
Rename resolvconf entry for maestro

### DIFF
--- a/networking/manager.go
+++ b/networking/manager.go
@@ -374,7 +374,7 @@ func (inst *networkManagerInstance) finalizeDns() (err error) {
 			return err2
 		}
 
-		cmd := exec.Command("resolvconf", "-a", "maestro.net")
+		cmd := exec.Command("resolvconf", "-a", "Maestro")
 
 		stdin, errp := cmd.StdinPipe()
 		if errp != nil {


### PR DESCRIPTION
Change resolvconf entry from maestro.net to Maestro

Indicates to resolvconf that this entry is program specific
and not attached to an interface