### PR TITLE
fix incorrect variable overwrite

### DIFF
--- a/sysstats/manager.go
+++ b/sysstats/manager.go
@@ -394,7 +394,6 @@ func (mgr *SysStats) ReadConfig(config *StatsConfig) (ok bool, err error) {
 		debugging.DEBUG_OUT("sysstats - VMStats out2: %+v\n", config.VMStats)
 		mgr.statCallers.Store(config.VMStats.statConfig.Name, RunnableStat(config.VMStats))
 	}
-	ok = statok
 	return
 }
 


### PR DESCRIPTION
fixed an issue found by static code analysis in which a variable
is incorrectly overwritten.