### PR TITLE
Yocto update fixes

### DIFF
--- a/processes/wakeupfd.go
+++ b/processes/wakeupfd.go
@@ -77,7 +77,7 @@ func (this *WakeupFd) ReadWakeup() (ret uint64, errno error) {
 // eventfd() is Linux specific
 // C def: int eventfd(unsigned int initval, int flags);
 func eventfd(initval uint, flags int) (fd int, errno error) {
-	val, _, err := syscall.RawSyscall(syscall.SYS_EVENTFD,
+	val, _, err := syscall.RawSyscall(syscall.SYS_EVENTFD2,
 		uintptr(initval),
 		uintptr(flags),
 		0)

--- a/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/deps/gperftools-2.4/src/stacktrace.cc
+++ b/vendor/github.com/armPelionEdge/greasego/deps/src/greaseLib/deps/gperftools-2.4/src/stacktrace.cc
@@ -123,7 +123,7 @@ struct GetStackImplementation {
 #define HAVE_GST_ppc
 #endif
 
-#if defined(__arm__)
+#if defined(__arm__) || defined(__aarch64__)
 #define STACKTRACE_INL_HEADER "stacktrace_arm-inl.h"
 #define GST_SUFFIX arm
 #include "stacktrace_impl_setup-inl.h"


### PR DESCRIPTION
Yocto update required two different changes:

    Adding support to 64 arm architecture, which required
    -- Adding aarm64 macro to gperftools stacktrace.cc
    -- Using SYSEVENTFD2 instead of SYSEVENTFD

    Building libuv with autogen instead of gyp.

Merging this allows removing 0001-aarch64-arm.patch, 0002-eventfd2.patch, 0003-build-with-autoconf.patch under each target from meta-pelion-edge. These files were introduced in follwoing PR:
PelionIoT/meta-pelion-edge#180