### PR TITLE
add github action to check PR base branch

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -1,0 +1,22 @@
+name: Check PR Base
+on:
+  pull_request:
+    types: [opened, edited]
+jobs:
+  check-pr-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject PR due to incorrect base
+        if: github.base_ref != 'dev' && (github.event.action == 'opened' || (github.event.action == 'edited' && github.event.changes.base.ref))
+        uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          event: REQUEST_CHANGES
+          body: 'Please change your PR base to dev branch.'
+      - name: Approve PR because it's based against dev branch
+        if: github.base_ref == 'dev' && github.event.changes.base && github.event.changes.base.ref.from != 'dev'
+        uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          event: APPROVE
+          body: 'Your PR is based against the dev branch.  Looks good.'


### PR DESCRIPTION
Reject any PRs not based against dev branch.  This should hopefully help
us avoid accidentally merging PRs against master.